### PR TITLE
feat(Filestore): add PathPrefix method to Filestore interface

### DIFF
--- a/castore.go
+++ b/castore.go
@@ -20,10 +20,11 @@ var (
 // It's currently form-fitting around IPFS (ipfs.io), with far-off plans to generalize
 // toward compatibility with git (git-scm.com), then maybe other stuff, who knows.
 type Filestore interface {
-	// put places a raw slice of bytes. Expect this to change to something like:
-	// Put(file File, options map[string]interface{}) (key datastore.Key, err error)
+	// Put places a file or a directory in the store.
 	// The most notable difference from a standard file store is the store itself determines
 	// the resulting key (google "content addressing" for more info ;)
+	// keys returned by put must be prefixed with the PathPrefix,
+	// eg. /ipfs/QmZ3KfGaSrb3cnTriJbddCzG7hwQi2j6km7Xe7hVpnsW5S
 	Put(file File, pin bool) (key datastore.Key, err error)
 
 	// Get retrieves the object `value` named by `key`.
@@ -47,6 +48,11 @@ type Filestore interface {
 	// expect this to change to something like:
 	// NewAdder(opt map[string]interface{}) (Adder, error)
 	NewAdder(pin, wrap bool) (Adder, error)
+
+	// PathPrefix is a top-level identifier to distinguish between filestores,
+	// for exmple: the "ipfs" in /ipfs/QmZ3KfGaSrb3cnTriJbddCzG7hwQi2j6km7Xe7hVpnsW5S
+	// a Filestore implementation should always return the same
+	PathPrefix() string
 }
 
 // Fetcher is the interface for getting files from a remote source

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+codecov:
+  ci:
+    - "ci/circle-ci"
+  notify:
+    require_ci_to_pass: no
+    after_n_builds: 2
+coverage:
+  range: "80...100"
+comment: off

--- a/ipfs/filestore_test.go
+++ b/ipfs/filestore_test.go
@@ -1,1 +1,36 @@
 package ipfs_filestore
+
+import (
+	"github.com/qri-io/cafs/test"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFilestore(t *testing.T) {
+	path := filepath.Join(os.TempDir(), "ipfs_cafs_test")
+	if err := os.MkdirAll(path, os.ModePerm); err != nil {
+		t.Errorf("error creating temp dir: %s", err.Error())
+		return
+	}
+	defer os.RemoveAll(path)
+
+	if err := InitRepo(path, ""); err != nil {
+		t.Errorf("error intializing repo: %s", err.Error())
+		return
+	}
+
+	f, err := NewFilestore(func(c *StoreCfg) {
+		c.Online = false
+		c.FsRepoPath = path
+	})
+	if err != nil {
+		t.Errorf("error creating filestore: %s", err.Error())
+		return
+	}
+
+	err = test.RunFilestoreTests(f)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+}

--- a/memfs/mem_filestore.go
+++ b/memfs/mem_filestore.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"io/ioutil"
-	"strings"
 
 	"github.com/ipfs/go-datastore"
 	"github.com/jbenet/go-base58"
@@ -22,17 +21,8 @@ func NewMapstore() cafs.Filestore {
 // TODO - fixme
 type MapStore map[datastore.Key]filer
 
-func (m MapStore) Tree() string {
-	buf := &bytes.Buffer{}
-	for path, file := range m {
-		buf.WriteString(path.String() + "\n")
-		// fmt.Println(path, file)
-		cafs.Walk(file.File(), 0, func(f cafs.File, depth int) error {
-			buf.WriteString(strings.Repeat("  ", depth+1) + f.FileName() + "\n")
-			return nil
-		})
-	}
-	return buf.String()
+func (m MapStore) PathPrefix() string {
+	return "map"
 }
 
 func (m MapStore) Put(file cafs.File, pin bool) (key datastore.Key, err error) {

--- a/memfs/mem_filestore_test.go
+++ b/memfs/mem_filestore_test.go
@@ -16,6 +16,13 @@ func TestMemFilestore(t *testing.T) {
 	}
 }
 
+func TestPathPrefix(t *testing.T) {
+	got := NewMapstore().PathPrefix()
+	if "map" != got {
+		t.Errorf("path prefix mismatch. expected: 'map', got: %s", got)
+	}
+}
+
 func RunFilestoreTests(f cafs.Filestore) error {
 	if err := SingleFile(f); err != nil {
 		return err

--- a/test/test.go
+++ b/test/test.go
@@ -18,6 +18,11 @@ func RunFilestoreTests(f cafs.Filestore) error {
 		return fmt.Errorf("Filestore.Put(%s) error: %s", file.FileName(), err.Error())
 	}
 
+	pre := "/" + f.PathPrefix() + "/"
+	if key.String()[:len(pre)] != pre {
+		return fmt.Errorf("key returned didn't return a that matches this Filestore's PathPrefix. Expected: %s/..., got: %s", pre, key.String())
+	}
+
 	outf, err := f.Get(key)
 	if err != nil {
 		return fmt.Errorf("Filestore.Get(%s) error: %s", key.String(), err.Error())
@@ -31,7 +36,7 @@ func RunFilestoreTests(f cafs.Filestore) error {
 		// return fmt.Errorf("mismatched return value from get: %s != %s", outf.FileName(), string(data))
 	}
 
-	has, err := f.Has(datastore.NewKey("----------no-match---------"))
+	has, err := f.Has(datastore.NewKey("no-match"))
 	if err != nil {
 		return fmt.Errorf("Filestore.Has([nonexistent key]) error: %s", err.Error())
 	}
@@ -39,6 +44,7 @@ func RunFilestoreTests(f cafs.Filestore) error {
 		return fmt.Errorf("filestore claims to have a very silly key")
 	}
 
+	// TODO - need to restore this, currently it'll make ipfs filestore tests fail
 	has, err = f.Has(key)
 	if err != nil {
 		return fmt.Errorf("Filestore.Has(%s) error: %s", key.String(), err.Error())


### PR DESCRIPTION
PathPrefix provides a high-level way to distinguish between different
types of filestore implementations, while at the same time reinforcing
the convention that all filestores must prefix their Keys with
a distinguishing prefix.
This'll help reinforce a uniform treatment of keys, which brings this
added benefit of being able to infer where a key came from.
Also, tests.