### PR TITLE
feat(cache, gcloud): new cache interface, starting into gcloud cache 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,11 +27,11 @@ jobs:
             github.com/ipfs/go-datastore
             github.com/jbenet/goprocess
             github.com/satori/go.uuid
-            leb.io/hashland/keccakpg
             github.com/jbenet/go-base58
             github.com/multiformats/go-multihash
             github.com/spaolacci/murmur3
             golang.org/x/crypto/blake2b
+            cloud.google.com/go/storage
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run:

--- a/cache.go
+++ b/cache.go
@@ -1,0 +1,34 @@
+package cafs
+
+import (
+	"time"
+
+	"github.com/ipfs/go-datastore"
+)
+
+// Cache is the interface for wrapping a cafs, cache behaviour will vary from case-to-case
+type Cache interface {
+	// Caches must fully implement filestores, this should always delegate operations
+	// to the underlying store at some point in each Filestore method call
+	Filestore
+	// Filestore must return the underlying filestore
+	Filestore() Filestore
+	// Cache explicitly adds a key to the Cache. it should be retrievable
+	// by the underlying store
+	Cache(key datastore.Key) error
+	// Uncache explicitly removes a key from the cache
+	Uncache(key datastore.Key) error
+}
+
+// TTECache is a cache that allows storing with an expiry
+type TTECache interface {
+	// TTECache implements the cache interface
+	Cache
+	// CacheTTE caches a key with a time-to-expiry
+	CacheTTE(key datastore.Key, tte time.Duration) error
+}
+
+// NewCacheFunc is a generic function for creating a cache
+// More sophisticated functions that configure caches & take lots of implementation-specific
+// details can return a NewCacheFunc instead of the cache itself to conform to this signature
+type NewCacheFunc func(fs Filestore) Cache

--- a/gcloud/cache.go
+++ b/gcloud/cache.go
@@ -8,7 +8,6 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/ipfs/go-datastore"
 	"github.com/qri-io/cafs"
-	"github.com/qri-io/cafs/memfs"
 )
 
 // CacheCfg configures cache behaviour
@@ -192,7 +191,7 @@ func (c Cache) getCache(key datastore.Key) (file cafs.File, err error) {
 		return nil, err
 	}
 
-	return memfs.NewMemfileReader(key.BaseNamespace(), r), err
+	return cafs.NewMemfileReader(key.BaseNamespace(), r), err
 }
 
 func (c Cache) deleteCache(key datastore.Key) error {

--- a/gcloud/cache.go
+++ b/gcloud/cache.go
@@ -1,0 +1,209 @@
+package gcloud
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"cloud.google.com/go/storage"
+	"github.com/ipfs/go-datastore"
+	"github.com/qri-io/cafs"
+	"github.com/qri-io/cafs/memfs"
+)
+
+// CacheCfg configures cache behaviour
+type CacheCfg struct {
+	// Setting Full == true will cache everything that is Put() into the store,
+	// and check the cache on all Get()/Has() requests (falling back to the store)
+	Full bool
+	// Async will skip waiting for writes to cache
+	AsyncWrite bool
+	// Set the kind of key to read & write from the store. cannot be empty
+	BucketName string
+
+	// MaxFileSize specifies how large a byte slice can be before it
+	// TODO - not yet implemented
+	// MaxFileSize int64
+}
+
+// Cache implements the cafs.Cache interface using a google cloud datastore
+type Cache struct {
+	ctx    context.Context
+	fs     cafs.Filestore
+	client *storage.Client
+	cfg    *CacheCfg
+}
+
+// NewCache creates a function that can create new cache from a filestore
+func NewCacheFunc(ctx context.Context, cli *storage.Client, opts ...func(*CacheCfg)) cafs.NewCacheFunc {
+	cfg := &CacheCfg{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	return cafs.NewCacheFunc(func(fs cafs.Filestore) cafs.Cache {
+		return Cache{
+			ctx:    ctx,
+			fs:     fs,
+			client: cli,
+			cfg:    cfg,
+		}
+	})
+}
+
+// Put places a file in the store
+func (c Cache) Put(file cafs.File, pin bool) (key datastore.Key, err error) {
+	key, err = c.fs.Put(file, pin)
+	if err != nil {
+		return
+	}
+
+	if c.shouldCache(file) {
+		if c.cfg.AsyncWrite {
+			go func() {
+				err := c.putCache(key)
+				if err != nil {
+					fmt.Errorf("error placing in cache: %s", err.Error())
+				}
+			}()
+		}
+		err = c.putCache(key)
+	}
+
+	return key, err
+}
+
+// Get
+func (c Cache) Get(key datastore.Key) (file cafs.File, err error) {
+	return c.fs.Get(key)
+}
+
+// Has checks for the presence of a key
+func (c Cache) Has(key datastore.Key) (bool, error) {
+	return c.fs.Has(key)
+}
+
+// Delete removes a key from the store, possibly affecting the cache
+func (c Cache) Delete(key datastore.Key) error {
+	return c.fs.Delete(key)
+}
+
+// PathPrefix returns the prefix of the underlying store
+func (c Cache) PathPrefix() string {
+	return c.fs.PathPrefix()
+}
+
+// NewAdder proxies the store NewAdder method
+func (c Cache) NewAdder(pin, wrap bool) (cafs.Adder, error) {
+	return c.fs.NewAdder(pin, wrap)
+	// fsAdder, err := c.fs.NewAdder(pin, wrap)
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	// adder := &adder{
+	// 	cache: &c,
+	// 	adder: fsAdder,
+	// 	out:   make(chan cafs.AddedFile, 9),
+	// }
+
+	// go func() {
+	// 	for af := range fsAdder.Added() {
+	// 		adder.out <- af
+	// 	}
+	// }()
+
+	// return adder
+}
+
+// Adder wraps a coreunix adder to conform to the cafs adder interface
+// type adder struct {
+// 	cache *Cache
+// 	adder cafs.Adder
+// 	out   chan cafs.AddedFile
+// }
+
+// func (a *adder) AddFile(f cafs.File) error {
+// 	if a.cache.shouldCache(f) {
+// 		pr, pw := io.Pipe()
+// 		r := io.TeeReader(f, pw)
+// 	}
+
+// 	// a.adder.AddFile(f cafs.File)
+// 	// // path, err := a.z.Put(f, a.pin)
+// 	// if err != nil {
+// 	// 	fmt.Errorf("error putting file in mapstore: %s", err.Error())
+// 	// 	return err
+// 	// }
+// 	// a.out <- cafs.AddedFile{
+// 	// 	Path:  path,
+// 	// 	Name:  f.FileName(),
+// 	// 	Bytes: 0,
+// 	// 	Hash:  path.String(),
+// 	// }
+// 	return nil
+// }
+
+// func (a *adder) Added() chan cafs.AddedFile {
+// 	return a.out
+// }
+
+// func (a *adder) Close() error {
+// 	close(a.out)
+// 	return nil
+// }
+
+// Filestore returns
+func (c Cache) Filestore() cafs.Filestore {
+	return c.fs
+}
+
+// Cache
+func (c Cache) Cache(key datastore.Key) error {
+	return c.putCache(key)
+}
+
+// Uncache removes a cache from the store
+func (c Cache) Uncache(key datastore.Key) error {
+	return c.deleteCache(key)
+}
+
+func (c Cache) shouldCache(file cafs.File) bool {
+	return c.cfg.Full
+}
+
+//
+func (c Cache) putCache(key datastore.Key) (err error) {
+	file, err := c.fs.Get(key)
+	if err != nil {
+		return err
+	}
+
+	w := c.object(key).NewWriter(c.ctx)
+	_, err = io.Copy(w, file)
+	return
+}
+
+//
+func (c Cache) getCache(key datastore.Key) (file cafs.File, err error) {
+	obj := c.object(key)
+	r, err := obj.NewReader(c.ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return memfs.NewMemfileReader(key.BaseNamespace(), r), err
+}
+
+func (c Cache) deleteCache(key datastore.Key) error {
+	return c.object(key).Delete(c.ctx)
+}
+
+func (c Cache) object(key datastore.Key) *storage.ObjectHandle {
+	return c.bucket().Object(key.String())
+}
+
+//
+func (c Cache) bucket() *storage.BucketHandle {
+	return c.client.Bucket(c.cfg.BucketName)
+}

--- a/gcloud/cache_test.go
+++ b/gcloud/cache_test.go
@@ -1,0 +1,26 @@
+package gcloud
+
+import (
+	"context"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/qri-io/cafs/test"
+	"google.golang.org/api/option"
+)
+
+func TestCache(t *testing.T) {
+	ctx := context.Background()
+	cli, err := storage.NewClient(ctx, option.WithoutAuthentication())
+	if err != nil {
+		t.Errorf("error creating client: %s", err.Error())
+		return
+	}
+
+	cf := NewCacheFunc(ctx, cli, func(c *CacheCfg) {
+		c.Full = true
+		c.BucketName = "qri_tests"
+	})
+
+	test.RunCacheTests(cf, t)
+}

--- a/gcloud/store.go
+++ b/gcloud/store.go
@@ -1,0 +1,231 @@
+package gcloud
+
+// import (
+// 	"crypto/sha256"
+// 	"fmt"
+// 	"github.com/multiformats/go-multihash"
+
+// 	"cloud.google.com/go/datastore"
+// 	ipfsds "github.com/ipfs/go-datastore"
+// 	"github.com/mr-tron/base58/base58"
+// 	"github.com/qri-io/cafs"
+// )
+
+// type Store struct {
+// 	client *datastore.Client
+// }
+
+// // NewMamstore allocates an instance of a mapstore
+// func New() cafs.Filestore {
+// 	return Store{}
+// }
+
+// // Put places a file or a directory in the store.
+// // The most notable difference from a standard file store is the store itself determines
+// // the resulting key (google "content addressing" for more info ;)
+// // keys returned by put must be prefixed with the PathPrefix,
+// // eg. /ipfs/QmZ3KfGaSrb3cnTriJbddCzG7hwQi2j6km7Xe7hVpnsW5S
+// func (s *Store) Put(file cafs.File, pin bool) (key ipfsds.Key, err error) {
+// 	if file.IsDirectory() {
+// 		buf := bytes.NewBuffer(nil)
+// 		dir := fsDir{
+// 			store: &m,
+// 			path:  file.FullPath(),
+// 			files: []datastore.Key{},
+// 		}
+
+// 		for {
+// 			f, e := file.NextFile()
+// 			if e != nil {
+// 				if e.Error() == "EOF" {
+// 					dirhash, e := hashBytes(buf.Bytes())
+// 					if err != nil {
+// 						err = fmt.Errorf("error hashing file data: %s", e.Error())
+// 						return
+// 					}
+// 					// fmt.Println("dirhash:", dirhash)
+// 					key = datastore.NewKey("/map/" + dirhash)
+// 					m[key] = dir
+// 					return
+
+// 				}
+// 				err = fmt.Errorf("error getting next file: %s", err.Error())
+// 				return
+// 			}
+
+// 			hash, e := m.Put(f, pin)
+// 			if e != nil {
+// 				err = fmt.Errorf("error putting file: %s", e.Error())
+// 				return
+// 			}
+// 			key = hash
+// 			dir.files = append(dir.files, hash)
+// 			_, err = buf.WriteString(key.String() + "\n")
+// 			if err != nil {
+// 				err = fmt.Errorf("error writing to buffer: %s", err.Error())
+// 				return
+// 			}
+// 		}
+
+// 	} else {
+// 		data, e := ioutil.ReadAll(file)
+// 		if e != nil {
+// 			err = fmt.Errorf("error reading from file: %s", e.Error())
+// 			return
+// 		}
+// 		hash, e := hashBytes(data)
+// 		if e != nil {
+// 			err = fmt.Errorf("error hashing file data: %s", e.Error())
+// 			return
+// 		}
+// 		key = datastore.NewKey("/map/" + hash)
+// 		m[key] = fsFile{name: file.FileName(), path: file.FullPath(), data: data}
+// 		return
+// 	}
+// 	return
+// }
+
+// // Get retrieves the object `value` named by `key`.
+// // Get will return ErrNotFound if the key is not mapped to a value.
+// func (s *Store) Get(key ipfsds.Key) (file cafs.File, err error) {
+// 	if m[key] == nil {
+// 		return nil, datastore.ErrNotFound
+// 	}
+// 	return m[key].File(), nil
+// }
+
+// // Has returns whether the `key` is mapped to a `value`.
+// // In some contexts, it may be much cheaper only to check for existence of
+// // a value, rather than retrieving the value itself. (e.g. HTTP HEAD).
+// // The default implementation is found in `GetBackedHas`.
+// func (s *Store) Has(key ipfsds.Key) (exists bool, err error) {
+// 	if m[key] == nil {
+// 		return false, nil
+// 	}
+// 	return true, nil
+// }
+
+// // Delete removes the value for given `key`.
+// func (s *Store) Delete(key ipfsds.Key) error {
+// 	return fmt.Errorf("not yet finished")
+// }
+
+// // NewAdder allocates an Adder instance for adding files to the filestore
+// // Adder gives a higher degree of control over the file adding process at the
+// // cost of being harder to work with.
+// // "pin" is a flag for recursively pinning this object
+// // "wrap" sets weather the top level should be wrapped in a directory
+// // expect this to change to something like:
+// // NewAdder(opt map[string]interface{}) (Adder, error)
+// func (s *Store) NewAdder(pin, wrap bool) (cafs.Adder, error) {
+// 	addedOut := make(chan cafs.AddedFile, 9)
+// 	return &adder{
+// 		mapstore: m,
+// 		out:      addedOut,
+// 	}, nil
+// }
+
+// // PathPrefix is a top-level identifier to distinguish between filestores,
+// // for exmple: the "ipfs" in /ipfs/QmZ3KfGaSrb3cnTriJbddCzG7hwQi2j6km7Xe7hVpnsW5S
+// // a Filestore implementation should always return the same value
+// func (s *Store) PathPrefix() string {
+// 	return "gcds"
+// }
+
+// // Fetch gets a file from a source
+// // func (s *Store) Fetch(source Source, key ipfsds.Key) (cafs.SizeFile, error) {
+// // }
+
+// // address should return the base resource identifier in either content
+// // or location based addressing schemes
+// func (s *Store) Address() string {
+// 	return "/gcds/"
+// }
+
+// func (m MapStore) NewAdder(pin, wrap bool) (cafs.Adder, error) {
+// 	addedOut := make(chan cafs.AddedFile, 9)
+// 	return &adder{
+// 		mapstore: m,
+// 		out:      addedOut,
+// 	}, nil
+// }
+
+// // Adder wraps a coreunix adder to conform to the cafs adder interface
+// type adder struct {
+// 	mapstore MapStore
+// 	pin      bool
+// 	out      chan cafs.AddedFile
+// }
+
+// func (a *adder) AddFile(f cafs.File) error {
+// 	path, err := a.mapstore.Put(f, a.pin)
+// 	if err != nil {
+// 		fmt.Errorf("error putting file in mapstore: %s", err.Error())
+// 		return err
+// 	}
+// 	a.out <- cafs.AddedFile{
+// 		Path:  path,
+// 		Name:  f.FileName(),
+// 		Bytes: 0,
+// 		Hash:  path.String(),
+// 	}
+// 	return nil
+// }
+
+// func (a *adder) Added() chan cafs.AddedFile {
+// 	return a.out
+// }
+// func (a *adder) Close() error {
+// 	close(a.out)
+// 	return nil
+// }
+
+// func hashBytes(data []byte) (hash string, err error) {
+// 	mhBuf, err := multihash.Encode(sha256.Sum256(data)[:], multihash.SHA2_256)
+// 	if err != nil {
+// 		err = fmt.Errorf("error encoding hash: %s", err.Error())
+// 		return
+// 	}
+// 	hash = base58.Encode(mhBuf)
+// 	return
+// }
+
+// type fsFile struct {
+// 	name string
+// 	path string
+// 	data []byte
+// }
+
+// func (f fsFile) File() cafs.File {
+// 	return &Memfile{
+// 		name: f.name,
+// 		path: f.path,
+// 		buf:  bytes.NewBuffer(f.data),
+// 	}
+// }
+
+// type fsDir struct {
+// 	store *MapStore
+// 	path  string
+// 	files []datastore.Key
+// }
+
+// func (f fsDir) File() cafs.File {
+// 	files := make([]cafs.File, len(f.files))
+// 	for i, path := range f.files {
+// 		file, err := f.store.Get(path)
+// 		if err != nil {
+// 			panic(path.String())
+// 		}
+// 		files[i] = file
+// 	}
+
+// 	return &Memdir{
+// 		path:     f.path,
+// 		children: files,
+// 	}
+// }
+
+// type filer interface {
+// 	File() cafs.File
+// }

--- a/ipfs/filestore.go
+++ b/ipfs/filestore.go
@@ -9,7 +9,6 @@ import (
 
 	datastore "github.com/ipfs/go-datastore"
 	cafs "github.com/qri-io/cafs"
-	memfs "github.com/qri-io/cafs/memfs"
 
 	ipfsds "gx/ipfs/QmVSase1JP7cq9QkPT46oNwdp9pT6kBkG3oqS14y3QcZjG/go-datastore"
 	blockservice "gx/ipfs/QmViBzgruNUoLNBnXcx8YWbDNwV8MNGEGKkLo6JGetygdw/go-ipfs/blockservice"
@@ -136,7 +135,7 @@ func (fs *Filestore) getKey(key datastore.Key) (cafs.File, error) {
 		return nil, fmt.Errorf("tar archive error: %s", err.Error())
 	}
 
-	return memfs.NewMemfileReader(key.String(), tr), nil
+	return cafs.NewMemfileReader(key.String(), tr), nil
 }
 
 // Adder wraps a coreunix adder to conform to the cafs adder interface
@@ -292,7 +291,7 @@ func (fs *Filestore) AddFile(file cafs.File, pin bool) (hash string, err error) 
 
 	// wrap in a folder if top level is a file
 	if !file.IsDirectory() {
-		file = memfs.NewMemdir("/", file)
+		file = cafs.NewMemdir("/", file)
 	}
 
 	errChan := make(chan error, 0)

--- a/ipfs/filestore_test.go
+++ b/ipfs/filestore_test.go
@@ -3,12 +3,13 @@ package ipfs_filestore
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/qri-io/cafs/memfs"
-	"github.com/qri-io/cafs/test"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/qri-io/cafs"
+	"github.com/qri-io/cafs/test"
 )
 
 func TestFilestore(t *testing.T) {
@@ -74,7 +75,7 @@ func BenchmarkRead(b *testing.B) {
 		return
 	}
 
-	key, err := f.Put(memfs.NewMemfileBytes(filepath.Base(egFilePath), data), true)
+	key, err := f.Put(cafs.NewMemfileBytes(filepath.Base(egFilePath), data), true)
 	if err != nil {
 		b.Errorf("error putting example file in store: %s", err.Error())
 		return

--- a/mapstore_test.go
+++ b/mapstore_test.go
@@ -1,4 +1,4 @@
-package memfs
+package cafs
 
 import (
 	"bytes"
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/ipfs/go-datastore"
-	"github.com/qri-io/cafs"
 )
 
 func TestMemFilestore(t *testing.T) {
@@ -24,7 +23,7 @@ func TestPathPrefix(t *testing.T) {
 	}
 }
 
-func RunFilestoreTests(f cafs.Filestore) error {
+func RunFilestoreTests(f Filestore) error {
 	if err := SingleFile(f); err != nil {
 		return err
 	}
@@ -40,7 +39,7 @@ func RunFilestoreTests(f cafs.Filestore) error {
 	return nil
 }
 
-func SingleFile(f cafs.Filestore) error {
+func SingleFile(f Filestore) error {
 	fdata := []byte("foo")
 	file := NewMemfileBytes("file.txt", fdata)
 	key, err := f.Put(file, false)
@@ -83,7 +82,7 @@ func SingleFile(f cafs.Filestore) error {
 	return nil
 }
 
-func Directory(f cafs.Filestore) error {
+func Directory(f Filestore) error {
 	file := NewMemdir("/a",
 		NewMemfileBytes("b.txt", []byte("a")),
 		NewMemdir("c",
@@ -110,7 +109,7 @@ func Directory(f cafs.Filestore) error {
 	}
 
 	paths := []string{}
-	cafs.Walk(outf, 0, func(f cafs.File, depth int) error {
+	Walk(outf, 0, func(f File, depth int) error {
 		paths = append(paths, f.FullPath())
 		return nil
 	})
@@ -132,7 +131,7 @@ func Directory(f cafs.Filestore) error {
 	return nil
 }
 
-func RunFilestoreAdderTests(f cafs.Filestore) error {
+func RunFilestoreAdderTests(f Filestore) error {
 	adder, err := f.NewAdder(false, false)
 	if err != nil {
 		return fmt.Errorf("Filestore.NewAdder(false,false) error: %s", err.Error())

--- a/memfile_test.go
+++ b/memfile_test.go
@@ -1,7 +1,6 @@
-package memfs
+package cafs
 
 import (
-	"github.com/qri-io/cafs"
 	"testing"
 )
 
@@ -35,7 +34,7 @@ func TestMemfile(t *testing.T) {
 	}
 
 	paths := []string{}
-	err := cafs.Walk(a, 0, func(f cafs.File, depth int) error {
+	err := Walk(a, 0, func(f File, depth int) error {
 		paths = append(paths, f.FullPath())
 		return nil
 	})
@@ -70,7 +69,7 @@ func TestMemdirMakeDirP(t *testing.T) {
 	}
 
 	paths := []string{}
-	err := cafs.Walk(dir, 0, func(f cafs.File, depth int) error {
+	err := Walk(dir, 0, func(f File, depth int) error {
 		paths = append(paths, f.FullPath())
 		return nil
 	})

--- a/test/cache.go
+++ b/test/cache.go
@@ -6,11 +6,10 @@ import (
 
 	"github.com/ipfs/go-datastore"
 	"github.com/qri-io/cafs"
-	"github.com/qri-io/cafs/memfs"
 )
 
 func RunCacheTests(cf cafs.NewCacheFunc, t *testing.T) {
-	fs := memfs.NewMapstore()
+	fs := cafs.NewMapstore()
 	cache := cf(fs)
 
 	Filestore(cf, t)
@@ -26,8 +25,8 @@ func RunCacheTests(cf cafs.NewCacheFunc, t *testing.T) {
 
 func Filestore(cf cafs.NewCacheFunc, t *testing.T) {
 	key := datastore.NewKey("/foo")
-	mf := memfs.NewMemfileBytes("foo", []byte("foo"))
-	mem := memfs.NewMapstore()
+	mf := cafs.NewMemfileBytes("foo", []byte("foo"))
+	mem := cafs.NewMapstore()
 	key, err := mem.Put(mf, false)
 	if err != nil {
 		t.Errorf("error configuring test MapStore: %s", err.Error())
@@ -44,7 +43,7 @@ func Filestore(cf cafs.NewCacheFunc, t *testing.T) {
 func File(cache cafs.Cache, t *testing.T) {
 	fs := cache.Filestore()
 	fdata := []byte("foo")
-	file := memfs.NewMemfileBytes("file.txt", fdata)
+	file := cafs.NewMemfileBytes("file.txt", fdata)
 
 	key, err := fs.Put(file, false)
 	if err != nil {
@@ -52,7 +51,7 @@ func File(cache cafs.Cache, t *testing.T) {
 		return
 	}
 
-	file = memfs.NewMemfileBytes("file.txt", fdata)
+	file = cafs.NewMemfileBytes("file.txt", fdata)
 	cacheKey, err := cache.Put(file, false)
 	if err != nil {
 		t.Errorf("Cache.Put(%s) error: %s", file.FileName(), err.Error())

--- a/test/cache.go
+++ b/test/cache.go
@@ -1,0 +1,91 @@
+package test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/ipfs/go-datastore"
+	"github.com/qri-io/cafs"
+	"github.com/qri-io/cafs/memfs"
+)
+
+func RunCacheTests(cf cafs.NewCacheFunc, t *testing.T) {
+	fs := memfs.NewMapstore()
+	cache := cf(fs)
+
+	Filestore(cf, t)
+
+	for _, test := range []func(cafs.Cache, *testing.T){
+		File,
+		Directory,
+		Adder,
+	} {
+		test(cache, t)
+	}
+}
+
+func Filestore(cf cafs.NewCacheFunc, t *testing.T) {
+	key := datastore.NewKey("/foo")
+	mf := memfs.NewMemfileBytes("foo", []byte("foo"))
+	mem := memfs.NewMapstore()
+	key, err := mem.Put(mf, false)
+	if err != nil {
+		t.Errorf("error configuring test MapStore: %s", err.Error())
+		return
+	}
+
+	cache := cf(mem)
+
+	if _, err := cache.Get(key); err != nil {
+		t.Errorf("cache.Filestore didn't return passed-in filestore. %v != %v", mem, cache)
+	}
+}
+
+func File(cache cafs.Cache, t *testing.T) {
+	fs := cache.Filestore()
+	fdata := []byte("foo")
+	file := memfs.NewMemfileBytes("file.txt", fdata)
+
+	key, err := fs.Put(file, false)
+	if err != nil {
+		t.Errorf("Filestore.Put(%s) error: %s", file.FileName(), err.Error())
+		return
+	}
+
+	file = memfs.NewMemfileBytes("file.txt", fdata)
+	cacheKey, err := cache.Put(file, false)
+	if err != nil {
+		t.Errorf("Cache.Put(%s) error: %s", file.FileName(), err.Error())
+		return
+	}
+
+	if !key.Equal(cacheKey) {
+		t.Errorf("Filestore.Put & Cache.Put returned different keys. fs: %s, cache: %s", key.String(), cacheKey.String())
+		return
+	}
+
+	out, err := cache.Get(key)
+	if err != nil {
+		t.Errorf("Cache.Get a newly-put file error: %s", err.Error())
+		return
+	}
+
+	p := make([]byte, len(fdata))
+	if _, err := out.Read(p); err != nil {
+		t.Errorf("error reading file: %s", err.Error())
+		return
+	}
+
+	if !bytes.Equal(fdata, p) {
+		t.Errorf("read byte mismatch: %s", err.Error())
+		return
+	}
+}
+
+func Directory(cache cafs.Cache, t *testing.T) {
+	// TODO :/
+}
+
+func Adder(cache cafs.Cache, t *testing.T) {
+	// TODO :/
+}

--- a/test/test.go
+++ b/test/test.go
@@ -7,12 +7,11 @@ import (
 
 	"github.com/ipfs/go-datastore"
 	"github.com/qri-io/cafs"
-	"github.com/qri-io/cafs/memfs"
 )
 
 func RunFilestoreTests(f cafs.Filestore) error {
 	fdata := []byte("foo")
-	file := memfs.NewMemfileBytes("file.txt", fdata)
+	file := cafs.NewMemfileBytes("file.txt", fdata)
 	key, err := f.Put(file, false)
 	if err != nil {
 		return fmt.Errorf("Filestore.Put(%s) error: %s", file.FileName(), err.Error())
@@ -70,7 +69,7 @@ func RunFilestoreAdderTests(f cafs.Filestore) error {
 	}
 
 	data := []byte("bar")
-	if err := adder.AddFile(memfs.NewMemfileBytes("test.txt", data)); err != nil {
+	if err := adder.AddFile(cafs.NewMemfileBytes("test.txt", data)); err != nil {
 		return fmt.Errorf("Adder.AddFile error: %s", err.Error())
 	}
 


### PR DESCRIPTION
Bring in our new cafs.Cache interface (WORK IN PROGRESS), and an initial gcloud cache WIP. This PR also merges the memfs package into cafs, which is going to break a bunch of stuff upstream (pull requests incoming on qri-io/dataset & qri-io/qri)