### PR TITLE
test(ipfs): make sure tmp repo directory has proper permissions on unix systems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/qri-io/cafs
     docker:
-      - image: circleci/golang:1.9
+      - image: circleci/golang:1.11
         environment:
           GOLANG_ENV: test
           PORT: 3000

--- a/ipfs/init_test.go
+++ b/ipfs/init_test.go
@@ -17,6 +17,9 @@ func TestInitRepo(t *testing.T) {
 
 	for i, c := range cases {
 		repoPath := filepath.Join(os.TempDir(), fmt.Sprintf("ipfs_init_test_repo_%d", i))
+		if err := os.MkdirAll(repoPath, os.ModePerm); err != nil {
+			t.Fatalf("case %d error creating temp dir for test: %s", i, err.Error())
+		}
 		if err := InitRepo(repoPath, c.configPath); err != nil {
 			t.Error(err.Error())
 		}


### PR DESCRIPTION
not making this dir beforehand was causing tests to fail. Good to know for the future.