### PR TITLE
feat(IPFS api): add options to enable IPFS API, pubsub

### DIFF
--- a/ipfs/config.go
+++ b/ipfs/config.go
@@ -28,6 +28,8 @@ type StoreCfg struct {
 	FsRepoPath string
 	// operating context
 	Ctx context.Context
+	// EnableAPI
+	EnableAPI bool
 }
 
 // DefaultConfig results in a local node that
@@ -39,6 +41,37 @@ func DefaultConfig() *StoreCfg {
 		},
 		FsRepoPath: "~/.ipfs",
 		Ctx:        context.Background(),
+	}
+}
+
+// Option is a function that adjusts the store configuration
+type Option func(o *StoreCfg)
+
+// OptEnablePubSub configures ipfs to use the experimental pubsub store
+func OptEnablePubSub(o *StoreCfg) {
+	o.BuildCfg.ExtraOpts = map[string]bool{
+		"pubsub": true,
+	}
+}
+
+// OptsFromMap detects options from a map based on special keywords
+func OptsFromMap(opts map[string]interface{}) Option {
+	return func(o *StoreCfg) {
+		if opts == nil {
+			return
+		}
+
+		if api, ok := opts["api"].(bool); ok {
+			o.EnableAPI = api
+		}
+
+		if ps, ok := opts["pubsub"].(bool); ok {
+			if o.BuildCfg.ExtraOpts == nil {
+				o.BuildCfg.ExtraOpts = map[string]bool{}
+			}
+			o.BuildCfg.ExtraOpts["pubsub"] = ps
+		}
+
 	}
 }
 

--- a/ipfs/filestore.go
+++ b/ipfs/filestore.go
@@ -38,7 +38,7 @@ func (f Filestore) PathPrefix() string {
 	return "ipfs"
 }
 
-func NewFilestore(config ...func(cfg *StoreCfg)) (*Filestore, error) {
+func NewFilestore(config ...Option) (*Filestore, error) {
 	cfg := DefaultConfig()
 	for _, option := range config {
 		option(cfg)
@@ -89,6 +89,15 @@ func (fs *Filestore) GoOnline() error {
 		node: node,
 		capi: coreapi.NewCoreAPI(node),
 	}
+
+	if cfg.EnableAPI {
+		go func() {
+			if err := fs.serveAPI(); err != nil {
+				log.Errorf("error serving IPFS HTTP api: %s", err)
+			}
+		}()
+	}
+
 	return nil
 }
 

--- a/ipfs/http_api.go
+++ b/ipfs/http_api.go
@@ -1,0 +1,58 @@
+package ipfs_filestore
+
+import (
+	"fmt"
+
+	ipfs_config "gx/ipfs/QmPEpj17FDRpc7K1aArKZp3RsHtzRMKykeK9GVgn4WQGPR/go-ipfs-config"
+	ipfs_commands "gx/ipfs/QmUJYo4etAQqFfSS2rarFAE97eNGB8ej64YkRT2SmsYD4r/go-ipfs/commands"
+	ipfs_core "gx/ipfs/QmUJYo4etAQqFfSS2rarFAE97eNGB8ej64YkRT2SmsYD4r/go-ipfs/core"
+	ipfs_corehttp "gx/ipfs/QmUJYo4etAQqFfSS2rarFAE97eNGB8ej64YkRT2SmsYD4r/go-ipfs/core/corehttp"
+)
+
+// serveAPI makes an IPFS node available over an HTTP api
+func (fs *Filestore) serveAPI() error {
+	if fs.node == nil {
+		return fmt.Errorf("node is required to serve IPFS HTTP API")
+	}
+
+	cfg := fs.cfg
+	addr := ""
+	if cfg.Repo != nil {
+		if ipfscfg, err := cfg.Repo.Config(); err == nil {
+			// TODO (b5): apparantly ipfs config supports multiple API multiaddrs?
+			// I dunno, for now just go with the most likely case of only assigning
+			// an address if one string is supplied
+			if len(ipfscfg.Addresses.API) == 1 {
+				addr = ipfscfg.Addresses.API[0]
+			}
+		}
+	}
+
+	opts := []ipfs_corehttp.ServeOption{
+		ipfs_corehttp.GatewayOption(true, "/ipfs", "/ipns"),
+		ipfs_corehttp.WebUIOption,
+		ipfs_corehttp.CommandsOption(cmdCtx(fs.node, cfg.FsRepoPath)),
+	}
+
+	// TODO (b5): I've added this fmt.Println because the corehttp package includes a println
+	// call to the affect of "API server listening on [addr]", which will be confusing to our
+	// users. We should chat with the protocol folks about making that print statement mutable
+	// or configurable
+	fmt.Println("starting IPFS HTTP API:")
+	return ipfs_corehttp.ListenAndServe(fs.node, addr, opts...)
+}
+
+// extracted from github.com/ipfs/go-ipfs/cmd/ipfswatch/main.go
+func cmdCtx(node *ipfs_core.IpfsNode, repoPath string) ipfs_commands.Context {
+	return ipfs_commands.Context{
+		Online:     true,
+		ConfigRoot: repoPath,
+		ReqLog:     &ipfs_commands.ReqLog{},
+		LoadConfig: func(path string) (*ipfs_config.Config, error) {
+			return node.Repo.Config()
+		},
+		ConstructNode: func() (*ipfs_core.IpfsNode, error) {
+			return node, nil
+		},
+	}
+}


### PR DESCRIPTION
It's high-time we made the IPFS api re-available. This adds configuration params that, when active, create an instance of an API at the address specified by the IPFS config file at Addresses.API. While we're in here, it's worth adding support for pubsub via configuration, as some users have requested that option.

I've also formalized the "Option" interface for configuring an ipfs filestore, and added a function for configuration via a map[string]interface{}, which the qri configuration will hold.